### PR TITLE
add code for typical90j

### DIFF
--- a/typical90j/README.md
+++ b/typical90j/README.md
@@ -1,0 +1,1 @@
+https://atcoder.jp/contests/typical90/tasks/typical90_j

--- a/typical90j/test_typical90j.py
+++ b/typical90j/test_typical90j.py
@@ -1,0 +1,33 @@
+import pytest
+from typical90j import get_score_totals
+
+
+@pytest.mark.parametrize(
+    "n, classes_and_scores, q, id_nums, expected",
+    [
+        (
+            7,
+            [[1, 72], [2, 78], [2, 94], [1, 23], [2, 89], [1, 40], [1, 75]],
+            1,
+            [[2, 6]],
+            [[63, 261]]
+
+        ),
+        (
+            7,
+            [[1, 72], [2, 78], [2, 94], [1, 23], [2, 89], [1, 40], [1, 75]],
+            10,
+            [[1, 3], [2, 4], [3, 5], [4, 6], [5, 7], [1, 5], [2, 6], [3, 7], [1, 6], [2, 7]],
+            [[72, 172], [23, 172], [23, 183], [63, 89], [115, 89], [95, 261], [63, 261], [138, 183], [135, 261], [138, 261]]
+        ),
+        (
+            1,
+            [[1, 100]],
+            3,
+            [[1, 1], [1, 1], [1, 1]],
+            [[100, 0], [100, 0], [100, 0]]
+        ),
+    ],
+)
+def test_get_score_totals(n: int, classes_and_scores: list, q: int, id_nums: list, expected: list):
+    assert get_score_totals(n, classes_and_scores, q, id_nums) == expected

--- a/typical90j/typical90j.py
+++ b/typical90j/typical90j.py
@@ -1,0 +1,22 @@
+def get_score_totals(n: int, classes_and_scores: list, q: int, id_nums: list) -> list:
+    l_id_nums = [a[0] - 1 for a in id_nums]
+    r_id_nums = [b[1] for b in id_nums]
+    classes = [c[0] for c in classes_and_scores]
+    scores = [d[1] for d in classes_and_scores]
+    score_totals = []
+
+    score_accms = [[0, 0]]  # 0のインデックス追加
+    score_accm_1 = 0
+    score_accm_2 = 0
+    for i in range(n):
+        if classes[i] == 1:
+            score_accm_1 += scores[i]
+        else:
+            score_accm_2 += scores[i]
+        score_accms.append([score_accm_1, score_accm_2])
+
+    for j in range(q):
+        score_total_1 = score_accms[r_id_nums[j]][0] - score_accms[l_id_nums[j]][0]
+        score_total_2 = score_accms[r_id_nums[j]][1] - score_accms[l_id_nums[j]][1]
+        score_totals.append([score_total_1, score_total_2])
+    return score_totals

--- a/typical90j/typical90j.py
+++ b/typical90j/typical90j.py
@@ -5,18 +5,18 @@ def get_score_totals(n: int, classes_and_scores: list, q: int, id_nums: list) ->
     scores = [d[1] for d in classes_and_scores]
     score_totals = []
 
-    score_accms = [[0, 0]]  # 0のインデックス追加
-    score_accm_1 = 0
-    score_accm_2 = 0
+    accumulations = [[0, 0]]  # 0のインデックス追加
+    accumulation_1 = 0
+    accumulation_2 = 0
     for i in range(n):
         if classes[i] == 1:
-            score_accm_1 += scores[i]
+            accumulation_1 += scores[i]
         else:
-            score_accm_2 += scores[i]
-        score_accms.append([score_accm_1, score_accm_2])
+            accumulation_2 += scores[i]
+        accumulations.append([accumulation_1, accumulation_2])
 
     for j in range(q):
-        score_total_1 = score_accms[r_id_nums[j]][0] - score_accms[l_id_nums[j]][0]
-        score_total_2 = score_accms[r_id_nums[j]][1] - score_accms[l_id_nums[j]][1]
+        score_total_1 = accumulations[r_id_nums[j]][0] - accumulations[l_id_nums[j]][0]
+        score_total_2 = accumulations[r_id_nums[j]][1] - accumulations[l_id_nums[j]][1]
         score_totals.append([score_total_1, score_total_2])
     return score_totals


### PR DESCRIPTION
- [この記事](https://ebisuke33.hatenablog.com/entry/typical90-2)の`Score Sum Queries`の項目を参考にしました
  - キーワード：累積和から区間の総和を求める
- 二次元配列の各要素のn番目だけを取り出す方法は[この記事](https://ja.stackoverflow.com/questions/47331/python%E3%81%A7%E4%BA%8C%E6%AC%A1%E5%85%83%E9%85%8D%E5%88%97%E3%81%AE%E4%B8%AD%E3%81%AE%E5%90%84%E8%A6%81%E7%B4%A0%E3%81%AEn%E7%95%AA%E7%9B%AE%E3%81%A0%E3%81%91%E3%82%92%E5%8F%96%E3%82%8A%E5%87%BA%E3%81%97%E3%81%A6-%E8%A6%81%E7%B4%A0%E3%81%A8%E3%81%97%E3%81%A6%E4%B8%A6%E3%81%B9%E3%81%9F%E3%81%84)を参考にしました
- インデックス番号がずれないように`score_accms`にまず`[0, 0]`を初期値として入れておくことや、`l_id_nums`の要素は元の要素から`-1`する必要があることが理解するのに時間がかかりました