### PR TITLE
add code for ABC251B

### DIFF
--- a/ABC251B/README.md
+++ b/ABC251B/README.md
@@ -1,0 +1,1 @@
+https://atcoder.jp/contests/abc251/tasks/abc251_b

--- a/ABC251B/abc251b.py
+++ b/ABC251B/abc251b.py
@@ -1,0 +1,15 @@
+import itertools
+
+n, w = map(int, input().split())
+weights = list(map(int, input().split()))
+nums = []  # 良い整数のリスト
+for i in range(1, 4):
+    num_combinations = list(itertools.combinations(weights, i))
+    # num_combinationsの中で組み合わせ同士の和を調べる
+    num_combinations_sums = list(map(sum, num_combinations))
+    for j in num_combinations_sums:
+        if j <= w:
+            nums.append(j)
+# 被っているリストを排除
+nums = set(nums)
+print(len(nums))

--- a/ABC251B/abc251b.py
+++ b/ABC251B/abc251b.py
@@ -1,15 +1,15 @@
 import itertools
 
 n, w = map(int, input().split())
-weights = list(map(int, input().split()))
+# 重さが0のおもりが2個あるとする
+weights = list(map(int, input().split())) + [0, 0]
 nums = []  # 良い整数のリスト
-for i in range(1, 4):
-    num_combinations = list(itertools.combinations(weights, i))
-    # num_combinationsの中で組み合わせ同士の和を調べる
-    num_combinations_sums = list(map(sum, num_combinations))
-    for j in num_combinations_sums:
-        if j <= w:
-            nums.append(j)
+num_combinations = list(itertools.combinations(weights, 3))
+# num_combinationsの中で組み合わせ同士の和を調べる
+num_combinations_sums = list(map(sum, num_combinations))
+for j in num_combinations_sums:
+    if j <= w:
+        nums.append(j)
 # 被っているリストを排除
 nums = set(nums)
 print(len(nums))


### PR DESCRIPTION
weightsの中から、1つ選ぶ、2つ選ぶ、3つ選ぶ組み合わせで2次元リストを作成し、それらの組み合わせ同士の和（行の和）を求め、w以下である和をリストにして、被っている和を排除しました。
被りを排除することを配慮できていなくて本番ではACできずでしたが、終了後に修正してACしました。

- `num_combinations = list(itertools.combinations(weights, i))`
- `num_combinations_sums = list(map(sum, num_combinations))`
はイテレータでできるか試しましたが、リストでないとエラーが出たのでリストにしました。

- 組み合わせ　[参考サイト](https://py-memo.com/python/itertool-per-com/)
- 2次元リストの行の和　[参考サイト](https://knuth256.com/2021/05/06/python3-%E3%80%802%E6%AC%A1%E5%85%83%E3%83%AA%E3%82%B9%E3%83%88%E3%81%AE%E5%90%88%E8%A8%88%E8%A1%8C%E3%83%BB%E5%88%97%E3%83%BB%E5%85%A8%E8%A6%81%E7%B4%A0%E3%82%92%E6%B1%82%E3%82%81%E3%82%8B%EF%BC%81/)