### PR TITLE
ABC260B

### DIFF
--- a/ABC260B/README.md
+++ b/ABC260B/README.md
@@ -1,0 +1,1 @@
+https://atcoder.jp/contests/abc260/tasks/abc260_b

--- a/ABC260B/abc260b.py
+++ b/ABC260B/abc260b.py
@@ -1,0 +1,26 @@
+N, X, Y, Z = map(int, input().split())
+A = list(map(int, input().split()))
+B = list(map(int, input().split()))
+passed = [False] * N
+
+# Math
+students = [(-A[i], i) for i in range(N)]
+students.sort()
+for i in range(X):
+    passed[students[i][1]] = True
+
+# English
+students = [(-B[i], i) for i in range(N) if not passed[i]]  # passedがFalseの人だけstudentsに入れる
+students.sort()
+for i in range(Y):
+    passed[students[i][1]] = True
+
+# Total
+students = [(-(A[i] + B[i]), i) for i in range(N) if not passed[i]]
+students.sort()
+for i in range(Z):
+    passed[students[i][1]] = True
+
+for i in range(N):
+    if passed[i]:
+        print(i + 1)

--- a/ABC260B/sample.py
+++ b/ABC260B/sample.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+
+class Examinee:
+    def __init__(self, id: int, math: int, english: int) -> None:
+        self.id = id
+        self.math = math
+        self.english = english
+        self.is_passed = False
+
+    def __repr__(self) -> str:
+        return f"[id: {self.id}, math: {self.math}, eng: {self.english}, passed: {self.is_passed}]"
+
+
+N, X, Y, Z = map(int, input().split())
+A = list(map(int, input().split()))
+B = list(map(int, input().split()))
+examinees: list[Examinee] = []
+for i in range(N):
+    examinees.append(Examinee(i + 1, A[i], B[i]))
+
+math_order = sorted(
+    filter(lambda x: not x.is_passed, examinees),
+    key=lambda x: (x.math, -1 * (x.id)),
+    reverse=True,
+)
+for i in range(X):
+    math_order[i].is_passed = True
+
+english_order = sorted(
+    filter(lambda x: not x.is_passed, examinees),
+    key=lambda x: (x.english, -1 * (x.id)),
+    reverse=True,
+)
+for i in range(Y):
+    english_order[i].is_passed = True
+
+score_order = sorted(
+    filter(lambda x: not x.is_passed, examinees),
+    key=lambda x: (x.math + x.english, -1 * (x.id)),
+    reverse=True,
+)
+for i in range(Z):
+    score_order[i].is_passed = True
+
+for passed in filter(lambda x: x.is_passed, examinees):
+    print(passed.id)

--- a/ABC260B/sample.py
+++ b/ABC260B/sample.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from __future__ import annotations  # 型アノテーションに自己のクラスを指定するため？
 
 
 class Examinee:
@@ -15,15 +15,17 @@ class Examinee:
 N, X, Y, Z = map(int, input().split())
 A = list(map(int, input().split()))
 B = list(map(int, input().split()))
-examinees: list[Examinee] = []
-for i in range(N):
-    examinees.append(Examinee(i + 1, A[i], B[i]))
+examinees: list[Examinee] = []  # 左辺は何をしてる？
 
+for i in range(N):
+    examinees.append(Examinee(i + 1, A[i], B[i]))  # [[id: 1, math: 80, eng: 40, passed: False], ...
+print(examinees)
 math_order = sorted(
-    filter(lambda x: not x.is_passed, examinees),
-    key=lambda x: (x.math, -1 * (x.id)),
-    reverse=True,
+    filter(lambda x: not x.is_passed, examinees),  # passedがFalseである要素を抽出、x.is_passedでどうやってアクセス？
+    key=lambda x: (x.math, -1 * (x.id)),  # ソートされる前に適応される関数を指定、()ついてるのなぜ？
+    reverse=True,  # 降順でソート
 )
+
 for i in range(X):
     math_order[i].is_passed = True
 

--- a/ABC260B/sample.py
+++ b/ABC260B/sample.py
@@ -1,4 +1,4 @@
-from __future__ import annotations  # 型アノテーションに自己のクラスを指定するため？
+from __future__ import annotations  # リストの型アノテーションつけるため
 
 
 class Examinee:
@@ -15,14 +15,16 @@ class Examinee:
 N, X, Y, Z = map(int, input().split())
 A = list(map(int, input().split()))
 B = list(map(int, input().split()))
-examinees: list[Examinee] = []  # 左辺は何をしてる？
+examinees: list[Examinee] = []  # 変数examineesにExaminee型の要素を格納したリストを指定
 
 for i in range(N):
-    examinees.append(Examinee(i + 1, A[i], B[i]))  # [[id: 1, math: 80, eng: 40, passed: False], ...
-print(examinees)
+    examinees.append(Examinee(i + 1, A[i], B[i]))  # examinees = [[id: 1, math: 80, eng: 40, passed: False], ...
+
+# 数学の点数を降順で、同点の場合id小さい順でソート
+# x=examineesの各要素.is_passedなどで値にアクセスできる 例:examinees[0].is_passed = False
 math_order = sorted(
-    filter(lambda x: not x.is_passed, examinees),  # passedがFalseである要素を抽出、x.is_passedでどうやってアクセス？
-    key=lambda x: (x.math, -1 * (x.id)),  # ソートされる前に適応される関数を指定、()ついてるのなぜ？
+    filter(lambda x: not x.is_passed, examinees),  # まだ合格してない人だけを抽出したリスト作成
+    key=lambda x: (x.math, -1 * (x.id)),  # idにマイナスつけることで番号小さい順に並ぶ
     reverse=True,  # 降順でソート
 )
 


### PR DESCRIPTION
受験番号（インデックス）を保持したまま、点数の大きい順でソートする方法でつまづきました。
参考にした解答では、`−(点数), インデックス`のタプルで`sort()`していて、なるほどとなりました、これだとタプルの0番目が同じだったら1番目で比較されるのでこれも問題の要求通りになります。（[参考](https://atcoder.jp/contests/abc260/submissions/33325462)）
